### PR TITLE
Change typo in man page

### DIFF
--- a/man/signoff.1.txt
+++ b/man/signoff.1.txt
@@ -63,7 +63,7 @@ Environment
 *ARCHWEB_USERNAME*::
 	The archweb username to use to log in to archweb.
 
-*ARCHWEB_USERNAME*::
+*ARCHWEB_PASSWORD*::
 	The archweb password to use to log in to archweb.
 
 Authors


### PR DESCRIPTION
- ARCHWEB_USERNAME was stated as the variable for the password