### PR TITLE
signoff: match pkginfo.format() new function sig

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ setup(
     install_requires=[
         "click",
         "python-dateutil",
-        "pyalpm",
+        "pyalpm>=0.9.0",
         "requests"
     ],
 

--- a/signoff/__init__.py
+++ b/signoff/__init__.py
@@ -231,10 +231,10 @@ def format_signoff_long(signoff_pkg, local_pkg, options):
 
     # last update, and install date if package is installed
     last_update = dateutil.parser.parse(signoff_pkg["last_update"]).timestamp()
-    attributes.append(format_attr("Last updated", last_update, format="time"))
+    attributes.append(format_attr("Last updated", last_update, format_str="time"))
     if local_pkg:
         attributes.append(
-            format_attr("Install date", local_pkg.installdate, format="time"))
+            format_attr("Install date", local_pkg.installdate, format_str="time"))
 
     # packager and comments
     attributes.append(format_attr("Packager", signoff_pkg["packager"]))


### PR DESCRIPTION
As of release 0.9.0, the format parameter in pkginfo was replaced with
format_str so as to not shadow the format builtin. Update the call on
arch-signoff to match this.