### PR TITLE
Make colorized output optional, defaulting to on

### DIFF
--- a/man/signoff.1.txt
+++ b/man/signoff.1.txt
@@ -55,6 +55,9 @@ Options
 *\--noconfirm*::
 	Don't ask for confirmation.
 
+*\--nocolor*::
+	Don't use color in putput.
+
 *-h, \--help*::
 	Show this message and exit.
 


### PR DESCRIPTION
Colorful output doesn't display properly on dumb terminals (not the name of a specific terminal but the broad class of terminals that don't bother to interpret most escape sequences), and some people find it distracting anyway.