### PR TITLE
Fix substring not found error

### DIFF
--- a/signoff/__init__.py
+++ b/signoff/__init__.py
@@ -173,6 +173,8 @@ def format_attr(*args, **kwargs):
     Format an attribute in pacman -Qi style.
     """
     formatted = pycman.pkginfo.format_attr(*args, **kwargs)
+    if not formatted:
+        return click.style("")
     index = formatted.index(":") + 1
     return click.style(formatted[:index], bold=True) + formatted[index:]
 


### PR DESCRIPTION
Seems like there are some strings we try to format, but there is nothing
there:

    Traceback (most recent call last):
    [...]
      File "signoff/__init__.py", line 178, in format_attr
        index = formatted.index(":") + 1
    ValueError: substring not found

This ensures we are only parsing strings with content, and not empty
strings.

Signed-off-by: Morten Linderud <morten@linderud.pw>